### PR TITLE
fixed blink bug

### DIFF
--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -40371,7 +40371,7 @@ GameObject:
   - component: {fileID: 1431286606}
   m_Layer: 0
   m_Name: RespawnGrid
-  m_TagString: Untagged
+  m_TagString: Respawn
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/BlinkPrototypeController.cs
+++ b/Assets/Scripts/BlinkPrototypeController.cs
@@ -49,7 +49,6 @@ public class BlinkPrototypeController : MonoBehaviour
 		{
 			isBlinking = true;
 			canBlink = false;
-			collider.enabled = false;
 		}
 
 		//print(collider.OverlapCollider(new ContactFilter2D().NoFilter(), new Collider2D[1]).ToString());
@@ -65,5 +64,11 @@ public class BlinkPrototypeController : MonoBehaviour
 			collider.enabled = true;
 		}
 
+	}
+
+	void OnCollisionEnter2D(Collision2D col) {
+		if (isBlinking && (col.gameObject.tag != "Respawn")) {
+			collider.enabled = false;
+		}
 	}
 }


### PR DESCRIPTION
Blink does not phase through the respawn walls now, if we want to add more non-blinkable objects just add more tags into the OnCollision2D method.